### PR TITLE
Add switch between Hosted Checkout and Mollie Components

### DIFF
--- a/src/app/components/form/checkoutform.tsx
+++ b/src/app/components/form/checkoutform.tsx
@@ -12,8 +12,9 @@ import {
     Table,
 } from '@radix-ui/themes';
 
-// Next logic
+// Next and React logic
 import { redirect } from 'next/navigation';
+import React from 'react';
 
 // Lib
 import { validateFormData, validateUrl } from '@/app/lib/validation';
@@ -22,6 +23,7 @@ import { mollieCreatePayment } from '@/app/lib/mollie';
 // Form components
 import CheckoutButton from './checkoutbutton';
 import PaymentMethods from './paymentmethods';
+import MethodSwitch from './switch';
 
 export default async function CheckoutForm() {
     // This Server Action takes the form data, validates it and creates a payment
@@ -324,7 +326,7 @@ export default async function CheckoutForm() {
                         >
                             Payment
                         </Heading>
-                        <PaymentMethods />
+                        <MethodSwitch prop={PaymentMethods()} />
                     </Flex>
                 </Grid>
                 <Flex

--- a/src/app/components/form/switch.tsx
+++ b/src/app/components/form/switch.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { SegmentedControl } from '@radix-ui/themes';
+
+import React, { Children, Suspense } from 'react';
+
+export default function MethodSwitch({ prop }: { prop: React.ReactNode }) {
+    const [value, setValue] = React.useState('hpp');
+    return (
+        <>
+            <SegmentedControl.Root
+                value={value}
+                onValueChange={(value) => {
+                    if (value) setValue(value);
+                }}
+            >
+                <SegmentedControl.Item value="hpp">
+                    Hosted Checkout
+                </SegmentedControl.Item>
+                <SegmentedControl.Item value="components">
+                    Components
+                </SegmentedControl.Item>
+            </SegmentedControl.Root>
+            {value === 'hpp' ? (
+                <Suspense fallback={<p>Loading Methods...</p>}>{prop}</Suspense>
+            ) : (
+                <div>Components</div>
+            )}
+        </>
+    );
+}

--- a/src/app/components/ui/paymentoverview.tsx
+++ b/src/app/components/ui/paymentoverview.tsx
@@ -2,7 +2,18 @@
 
 // UI Components
 
-import { Flex, Code, Card, DataList, Button } from '@radix-ui/themes';
+import {
+    Flex,
+    Code,
+    Card,
+    DataList,
+    Button,
+    Separator,
+    Dialog,
+    ScrollArea,
+    Text,
+    Heading,
+} from '@radix-ui/themes';
 import StateBadge from './orderstatebadge';
 
 // Routing
@@ -64,25 +75,60 @@ export default async function PaymentOverview({ id }: { id: string }) {
                                 <Code variant="ghost">{payment.method}</Code>
                             </DataList.Value>
                         </DataList.Item>
-                        <DataList.Item align="center">
-                            <DataList.Label>Dashboard</DataList.Label>
-                            <DataList.Value>
-                                <Link
-                                    href={
-                                        'https://my.mollie.com/dashboard/org_19122057/payments/' +
-                                        payment.id
-                                    }
-                                >
-                                    <Button
-                                        size="1"
-                                        variant="soft"
-                                    >
-                                        Link
-                                    </Button>
-                                </Link>
-                            </DataList.Value>
-                        </DataList.Item>
                     </DataList.Root>
+                    <Separator
+                        my="3"
+                        size="4"
+                    />
+                    <Flex
+                        justify="center"
+                        align="center"
+                        gap="2"
+                    >
+                        <Link href={payment._links.dashboard.href}>
+                            <Button
+                                size="1"
+                                variant="soft"
+                            >
+                                Mollie Dashboard
+                            </Button>
+                        </Link>
+                        <Dialog.Root>
+                            <Dialog.Trigger>
+                                <Button
+                                    size="1"
+                                    variant="soft"
+                                >
+                                    Raw Payment Data
+                                </Button>
+                            </Dialog.Trigger>
+                            <Dialog.Content>
+                                <Dialog.Title>Raw Payment Data</Dialog.Title>
+                                <Separator
+                                    my="2"
+                                    size="4"
+                                />
+                                <ScrollArea style={{ height: 480 }}>
+                                    <Text size="1">
+                                        <pre>
+                                            {JSON.stringify(payment, null, 2)}
+                                        </pre>
+                                    </Text>
+                                </ScrollArea>
+                            </Dialog.Content>
+                        </Dialog.Root>
+                        {payment._links.changePaymentState && (
+                            <Link href={payment._links.changePaymentState.href}>
+                                <Button
+                                    size="1"
+                                    color="red"
+                                    variant="soft"
+                                >
+                                    Change State
+                                </Button>
+                            </Link>
+                        )}
+                    </Flex>
                 </Card>
             </Flex>
         </Flex>

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { RocketIcon } from '@radix-ui/react-icons';
-import { Callout, Flex, Heading } from '@radix-ui/themes';
+import { Callout, Flex, Heading, Em } from '@radix-ui/themes';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
@@ -36,8 +36,8 @@ export default function Page() {
                             <RocketIcon />
                         </Callout.Icon>
                         <Callout.Text>
-                            Your Order is authorized! You'll be redirected to
-                            the checkout soon.
+                            Thank you for your payment! You'll be redirected to
+                            the checkout soon to pay <Em>even more!</Em>
                         </Callout.Text>
                     </Callout.Root>
                 </Flex>


### PR DESCRIPTION
This introduces a switch in the checkout that toggles between a card with available payment methods that are dynamically retrieved from the `methods` API and a card that displays Mollies components for credit cards.

See: https://docs.mollie.com/docs/mollie-components

Since the card with available payment methods is a server component, we will pass it as a prop to a client component, wrapping it in suspension so the UI can update async