### PR TITLE
Add more countries and currencies

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -10,7 +10,7 @@ import MethodsSkeleton from '../components/form/methods/methodskeleton';
 import { Suspense } from 'react';
 
 // Validation for Currency Strings
-import { validateCurrency } from '../lib/validation';
+import { validateCurrency, validateCountry } from '../lib/validation';
 
 // invalidate page cache every 5 minutes to pick up new available payment methods
 export const revalidate = 300;
@@ -18,12 +18,15 @@ export const revalidate = 300;
 export default async function Page(props: {
     searchParams?: Promise<{
         currency?: string;
+        country?: string;
     }>;
 }) {
     const searchParams = await props.searchParams;
     const currency = searchParams?.currency || 'EUR';
+    const country = searchParams?.country || 'DE';
     // Validate the currency
     const validatedCurrency = await validateCurrency(currency);
+    const validatedCountry = await validateCountry(country);
 
     return (
         <main>
@@ -35,7 +38,10 @@ export default async function Page(props: {
                         key={validatedCurrency}
                         fallback={<MethodsSkeleton />}
                     >
-                        <HostedPaymentMethods currency={validatedCurrency} />
+                        <HostedPaymentMethods
+                            currency={validatedCurrency}
+                            country={validatedCountry}
+                        />
                     </Suspense>
                 }
             />

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -35,7 +35,7 @@ export default async function Page(props: {
                 hostedmethods={
                     <Suspense
                         // use the validated currency as key to re-trigger suspense when currency changes
-                        key={validatedCurrency}
+                        key={validatedCurrency + validatedCountry}
                         fallback={<MethodsSkeleton />}
                     >
                         <HostedPaymentMethods

--- a/src/app/components/form/SelectCountry.tsx
+++ b/src/app/components/form/SelectCountry.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { Select, Text } from '@radix-ui/themes';
+
+import { useState } from 'react';
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
+
+export default function SelectCountry() {
+    const [country, setCountry] = useState('DE');
+    const searchParams = useSearchParams();
+    const pathname = usePathname();
+    const { replace } = useRouter();
+
+    function handleCountryChange(country: string) {
+        setCountry(country);
+        const params = new URLSearchParams(searchParams);
+        if (country) {
+            params.set('country', country);
+        } else {
+            params.delete('country');
+        }
+        replace(`${pathname}?${params.toString()}`, {
+            scroll: false,
+        });
+    }
+
+    return (
+        <>
+            <Text as="label">Country</Text>
+            <Select.Root
+                value={country}
+                onValueChange={handleCountryChange}
+                defaultValue="DE"
+                name="country"
+                aria-label="Country"
+                required
+            >
+                <Select.Trigger />
+                <Select.Content>
+                    <Select.Item
+                        value="DE"
+                        id="DE"
+                        aria-label="Germany"
+                    >
+                        🇩🇪 Germany
+                    </Select.Item>
+                    <Select.Item
+                        value="AT"
+                        id="AT"
+                        aria-label="Austria"
+                    >
+                        🇦🇹 Austria
+                    </Select.Item>
+                    <Select.Item
+                        value="NL"
+                        id="NL"
+                        aria-label="Netherlands"
+                    >
+                        🇳🇱 Netherlands
+                    </Select.Item>
+                    <Select.Item
+                        value="UK"
+                        id="UK"
+                        aria-label="United Kingdom"
+                    >
+                        🇬🇧 United Kingdom
+                    </Select.Item>
+                    <Select.Item
+                        value="SE"
+                        id="SE"
+                        aria-label="Sweden"
+                    >
+                        🇸🇪 Sweden
+                    </Select.Item>
+                    <Select.Item
+                        value="PT"
+                        id="PT"
+                        aria-label="Portugal"
+                    >
+                        🇵🇹 Portugal
+                    </Select.Item>
+                    <Select.Item
+                        value="IT"
+                        id="IT"
+                        aria-label="Italy"
+                    >
+                        🇮🇹 Italy
+                    </Select.Item>
+                </Select.Content>
+            </Select.Root>
+        </>
+    );
+}

--- a/src/app/components/form/address.tsx
+++ b/src/app/components/form/address.tsx
@@ -184,35 +184,49 @@ export default async function Address() {
                                 id="DE"
                                 aria-label="Germany"
                             >
-                                Germany
+                                🇩🇪 Germany
                             </Select.Item>
                             <Select.Item
                                 value="AT"
                                 id="AT"
                                 aria-label="Austria"
                             >
-                                Austria
+                                🇦🇹 Austria
                             </Select.Item>
                             <Select.Item
                                 value="NL"
                                 id="NL"
                                 aria-label="Netherlands"
                             >
-                                Netherlands
+                                🇳🇱 Netherlands
                             </Select.Item>
                             <Select.Item
                                 value="UK"
                                 id="UK"
                                 aria-label="United Kingdom"
                             >
-                                United Kingdom
+                                🇬🇧 United Kingdom
                             </Select.Item>
                             <Select.Item
-                                value="XI"
-                                id="XI"
-                                aria-label="Northern Ireland"
+                                value="SE"
+                                id="SE"
+                                aria-label="Sweden"
                             >
-                                Northern Ireland (will error)
+                                🇸🇪 Sweden
+                            </Select.Item>
+                            <Select.Item
+                                value="PT"
+                                id="PT"
+                                aria-label="Portugal"
+                            >
+                                🇵🇹 Portugal
+                            </Select.Item>
+                            <Select.Item
+                                value="IT"
+                                id="IT"
+                                aria-label="Italy"
+                            >
+                                🇮🇹 Italy
                             </Select.Item>
                         </Select.Content>
                     </Select.Root>

--- a/src/app/components/form/address.tsx
+++ b/src/app/components/form/address.tsx
@@ -8,6 +8,7 @@ import {
     Select,
     Switch,
 } from '@radix-ui/themes';
+import SelectCountry from './SelectCountry';
 
 export default async function Address() {
     return (
@@ -170,66 +171,7 @@ export default async function Address() {
                     direction="column"
                     gap="1"
                 >
-                    <Text as="label">Country</Text>
-                    <Select.Root
-                        defaultValue="DE"
-                        name="country"
-                        aria-label="Country"
-                        required
-                    >
-                        <Select.Trigger />
-                        <Select.Content>
-                            <Select.Item
-                                value="DE"
-                                id="DE"
-                                aria-label="Germany"
-                            >
-                                🇩🇪 Germany
-                            </Select.Item>
-                            <Select.Item
-                                value="AT"
-                                id="AT"
-                                aria-label="Austria"
-                            >
-                                🇦🇹 Austria
-                            </Select.Item>
-                            <Select.Item
-                                value="NL"
-                                id="NL"
-                                aria-label="Netherlands"
-                            >
-                                🇳🇱 Netherlands
-                            </Select.Item>
-                            <Select.Item
-                                value="UK"
-                                id="UK"
-                                aria-label="United Kingdom"
-                            >
-                                🇬🇧 United Kingdom
-                            </Select.Item>
-                            <Select.Item
-                                value="SE"
-                                id="SE"
-                                aria-label="Sweden"
-                            >
-                                🇸🇪 Sweden
-                            </Select.Item>
-                            <Select.Item
-                                value="PT"
-                                id="PT"
-                                aria-label="Portugal"
-                            >
-                                🇵🇹 Portugal
-                            </Select.Item>
-                            <Select.Item
-                                value="IT"
-                                id="IT"
-                                aria-label="Italy"
-                            >
-                                🇮🇹 Italy
-                            </Select.Item>
-                        </Select.Content>
-                    </Select.Root>
+                    <SelectCountry />
                 </Flex>
             </Grid>
             <Separator

--- a/src/app/components/form/methods/hostedpaymentmethods.tsx
+++ b/src/app/components/form/methods/hostedpaymentmethods.tsx
@@ -15,10 +15,12 @@ import { mollieGetMethods } from '@/app/lib/mollie';
 
 export default async function HostedPaymentMethodCards({
     currency,
+    country,
 }: {
     currency?: string;
+    country?: string;
 }) {
-    const methods = await mollieGetMethods(currency);
+    const methods = await mollieGetMethods(currency, country);
 
     return (
         <>

--- a/src/app/components/form/shoppingcart.tsx
+++ b/src/app/components/form/shoppingcart.tsx
@@ -9,6 +9,7 @@ const CURRENCY_SYMBOLS = {
     EUR: '€',
     SEK: 'kr',
     GBP: '£',
+    USD: '$',
 };
 
 // Product data
@@ -63,7 +64,7 @@ export default function ShoppingCart() {
             CURRENCY_SYMBOLS[currency as keyof typeof CURRENCY_SYMBOLS];
 
         // Format based on currency style
-        if (currency === 'GBP') {
+        if (currency === 'GBP' || currency === 'USD') {
             return `${symbol}${price.toFixed(2).replace('.', ',')}`;
         } else {
             return `${price.toFixed(2).replace('.', ',')} ${symbol}`;
@@ -95,6 +96,7 @@ export default function ShoppingCart() {
                         <Select.Item value="EUR">EUR (€)</Select.Item>
                         <Select.Item value="SEK">SEK (kr)</Select.Item>
                         <Select.Item value="GBP">GBP (£)</Select.Item>
+                        <Select.Item value="USD">USD ($)</Select.Item>
                     </Select.Content>
                 </Select.Root>
             </Flex>

--- a/src/app/lib/mollie.ts
+++ b/src/app/lib/mollie.ts
@@ -132,9 +132,14 @@ export async function mollieGetPayment(id: string) {
 // this way we can filter the available payment methods.
 
 export async function mollieGetMethods(currency: string = 'EUR') {
+    let locale = Locale.en_US;
+    // TODO: set locale based on billing country
+    if (currency === 'SEK') {
+        locale = Locale.sv_SE;
+    }
     const methods = await mollieClient.methods.list({
         sequenceType: SequenceType.oneoff,
-        locale: Locale.en_US,
+        locale: locale,
         resource: 'payments',
         amount: { currency: currency, value: '220.00' },
     });

--- a/src/app/lib/mollie.ts
+++ b/src/app/lib/mollie.ts
@@ -19,6 +19,26 @@ if (!apiKey) {
 // Set up Mollie API client
 const mollieClient = createMollieClient({ apiKey: apiKey });
 
+// translate countries to locales
+const countryToLocale: Record<string, Locale> = {
+    DE: Locale.de_DE,
+    AT: Locale.de_AT,
+    NL: Locale.nl_NL,
+    UK: Locale.en_US,
+    SE: Locale.sv_SE,
+    PT: Locale.pt_PT,
+    IT: Locale.it_IT,
+};
+
+// function to get the locale for a given country
+function getLocaleForCountry(country: string): Locale {
+    let locale = countryToLocale[country];
+    if (!locale) {
+        locale = Locale.en_US; // default to English if country is not found
+    }
+    return locale;
+}
+
 // Create a payment using data gathered from the checkout form
 export async function mollieCreatePayment({
     firstname,
@@ -108,6 +128,7 @@ export async function mollieCreatePayment({
         ...{ billingAddress },
         cardToken: cardToken,
         captureMode: captureMode,
+        locale: getLocaleForCountry(country),
     });
     const redirectUrl = payment.getCheckoutUrl();
     return redirectUrl;
@@ -131,12 +152,12 @@ export async function mollieGetPayment(id: string) {
 // we're passing some additional info like sequencetype, locale and amount
 // this way we can filter the available payment methods.
 
-export async function mollieGetMethods(currency: string = 'EUR') {
+export async function mollieGetMethods(
+    currency: string = 'EUR',
+    country: string = 'DE'
+) {
     let locale = Locale.en_US;
-    // TODO: set locale based on billing country
-    if (currency === 'SEK') {
-        locale = Locale.sv_SE;
-    }
+    locale = getLocaleForCountry(country);
     const methods = await mollieClient.methods.list({
         sequenceType: SequenceType.oneoff,
         locale: locale,

--- a/src/app/lib/validation.ts
+++ b/src/app/lib/validation.ts
@@ -24,7 +24,7 @@ export async function validateFormData(formData: FormData) {
         zip_code: z
             .string()
             .min(1, { message: 'Must be at least 1 character long.' }),
-        country: z.string().length(2),
+        country: z.string().toUpperCase().length(2),
         payment_method: z.nativeEnum(PaymentMethod),
         cardToken: z.string().startsWith('tkn_').optional(),
         captureMode: z.nativeEnum(CaptureMethod).optional(),
@@ -66,5 +66,15 @@ export async function validateCurrency(currency: string) {
         return result;
     } catch (error) {
         throw new Error(`No valid currency.`);
+    }
+}
+
+export async function validateCountry(country: string) {
+    const currencySchema = z.string().toUpperCase().length(2);
+    try {
+        const result = currencySchema.parse(country);
+        return result;
+    } catch (error) {
+        throw new Error(`No valid country.`);
     }
 }


### PR DESCRIPTION
Right now we're querying the methods API whenever the currency changes. But we could also set the locale of the request based on the selected billing country!

To Do:
- refactor country selector into a client component and track its state through search params
- make method selection component accept country as a prop
- translate selected country to locale in `mollie.ts`
- set locale in methods API request and also in payment request