### PR TITLE
Add billink as supported payment method

### DIFF
--- a/src/app/lib/types.ts
+++ b/src/app/lib/types.ts
@@ -8,6 +8,7 @@ export const ExtendedPaymentMethod = z.enum([
     // Add beta payment methods here for testing
     'bizum',
     'vippsmobilepay',
+    'billink',
 ] as const);
 
 // Export the type for use in other files


### PR DESCRIPTION
Extends the ExtendedPaymentMethod enum to include billink, allowing it to pass form validation and be sent to the Mollie API.