### PR TITLE
Refactor payments page: responsive table, mobile cards, pagination, live toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ next-env.d.ts
 .github/instructions
 AGENTS.md
 copilot-instructions.md
+CLAUDE.md

--- a/src/app/components/form/paymentlogo.tsx
+++ b/src/app/components/form/paymentlogo.tsx
@@ -9,6 +9,7 @@ export default function PaymentLogo({ method }: { method: string }) {
             <Image
                 src={`https://mollie.com/external/icons/payment-methods/${method}.svg`}
                 alt={method}
+                title={method}
                 height={24}
                 width={32}
             />

--- a/src/app/components/ui/PaymentCards.tsx
+++ b/src/app/components/ui/PaymentCards.tsx
@@ -1,0 +1,45 @@
+import { Card, Flex, Text } from '@radix-ui/themes';
+import { Payment } from '@mollie/api-client';
+import Link from 'next/link';
+import StateBadge from './orderstatebadge';
+import PaymentLogo from '../form/paymentlogo';
+
+export default function PaymentCards({ payments }: { payments: Payment[] }) {
+    return (
+        <Flex direction="column" gap="3" pt="4">
+            {payments.map((payment) => (
+                <Card key={payment.id} asChild>
+                    <Link href={`/payments/${payment.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+                        <Flex justify="between" align="center">
+                            <Flex align="center" gap="2">
+                                {payment.method && (
+                                    <PaymentLogo method={payment.method as string} />
+                                )}
+                                <Text size="2" color="gray">
+                                    {payment.method ?? '—'}
+                                </Text>
+                            </Flex>
+                            <StateBadge state={payment.status} />
+                        </Flex>
+                        <Flex justify="between" align="end" mt="2">
+                            <Flex direction="column" gap="1">
+                                <Text size="4" weight="bold">
+                                    {payment.amount.currency} {payment.amount.value}
+                                </Text>
+                                <Text size="1" color="gray">
+                                    {new Date(payment.createdAt).toLocaleString('de-DE', {
+                                        dateStyle: 'medium',
+                                        timeStyle: 'short',
+                                    })}
+                                </Text>
+                            </Flex>
+                            <Text size="1" color="gray">
+                                {payment.id}
+                            </Text>
+                        </Flex>
+                    </Link>
+                </Card>
+            ))}
+        </Flex>
+    );
+}

--- a/src/app/components/ui/PaymentsControls.tsx
+++ b/src/app/components/ui/PaymentsControls.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { Switch, Flex, Text, Button, Tooltip } from '@radix-ui/themes';
+import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+interface PaymentsControlsProps {
+    isMollie: boolean;
+    mode: 'test' | 'live';
+    nextCursor: string | null;
+    prevCursor: string | null;
+}
+
+export default function PaymentsControls({
+    isMollie,
+    mode,
+    nextCursor,
+    prevCursor,
+}: PaymentsControlsProps) {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+
+    function buildParams(updates: Record<string, string | null>) {
+        const params = new URLSearchParams(searchParams.toString());
+        for (const [key, value] of Object.entries(updates)) {
+            if (value === null) {
+                params.delete(key);
+            } else {
+                params.set(key, value);
+            }
+        }
+        const qs = params.toString();
+        return qs ? `?${qs}` : '';
+    }
+
+    function handleModeChange(live: boolean) {
+        router.push(`/payments${buildParams({ mode: live ? 'live' : null, from: null })}`);
+    }
+
+    function handlePrev() {
+        if (prevCursor) router.push(`/payments${buildParams({ from: prevCursor })}`);
+    }
+
+    function handleNext() {
+        if (nextCursor) router.push(`/payments${buildParams({ from: nextCursor })}`);
+    }
+
+    const liveToggle = (
+        <Flex align="center" gap="2">
+            <Text size="2">Live payments</Text>
+            <Switch
+                checked={mode === 'live'}
+                onCheckedChange={handleModeChange}
+                disabled={!isMollie}
+            />
+        </Flex>
+    );
+
+    return (
+        <Flex justify="between" align="center">
+            {!isMollie ? (
+                <Tooltip content="Sign in with your @mollie.com email to view live payments.">
+                    {liveToggle}
+                </Tooltip>
+            ) : liveToggle}
+            <Flex gap="2">
+                <Button variant="outline" disabled={!prevCursor} onClick={handlePrev}>
+                    <ChevronLeftIcon />
+                    Previous
+                </Button>
+                <Button variant="outline" disabled={!nextCursor} onClick={handleNext}>
+                    Next
+                    <ChevronRightIcon />
+                </Button>
+            </Flex>
+        </Flex>
+    );
+}

--- a/src/app/components/ui/paymentstable.tsx
+++ b/src/app/components/ui/paymentstable.tsx
@@ -1,86 +1,92 @@
-'use server';
-
-// UI Components
 import { Flex, Table, IconButton } from '@radix-ui/themes';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';
-import StateBadge from './orderstatebadge';
-
-// Routing
+import { Payment } from '@mollie/api-client';
 import Link from 'next/link';
+import StateBadge from './orderstatebadge';
+import PaymentLogo from '../form/paymentlogo';
 
-// Mollie API
-import { mollieGetPayments } from '@/app/lib/mollie';
-
-export default async function PaymentsTable() {
-    const payments = await mollieGetPayments();
+export default function PaymentsTable({ payments }: { payments: Payment[] }) {
     return (
-        <Flex
-            justify="center"
-            pt="4"
-        >
-            <Flex>
-                <Table.Root
-                    variant="ghost"
-                    size={{
-                        initial: '1',
-                        sm: '2',
-                        lg: '3',
-                    }}
-                >
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.ColumnHeaderCell align="center">
-                                Payment ID
-                            </Table.ColumnHeaderCell>
-                            <Table.ColumnHeaderCell align="center">
-                                Created At
-                            </Table.ColumnHeaderCell>
-                            <Table.ColumnHeaderCell align="center">
-                                Status
-                            </Table.ColumnHeaderCell>
-                            <Table.ColumnHeaderCell align="center">
-                                Details
-                            </Table.ColumnHeaderCell>
-                        </Table.Row>
-                    </Table.Header>
+        <Flex justify="center" pt="4">
+            <Table.Root
+                variant="ghost"
+                size={{ initial: '1', sm: '2', lg: '3' }}
+                style={{ width: '100%' }}
+            >
+                <Table.Header>
+                    <Table.Row>
+                        <Table.ColumnHeaderCell>Method</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Timestamp</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Amount</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell className="hidden sm:table-cell">
+                            Status
+                        </Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell className="hidden md:table-cell">
+                            Description
+                        </Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell className="hidden lg:table-cell">
+                            Payment ID
+                        </Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Details</Table.ColumnHeaderCell>
+                    </Table.Row>
+                </Table.Header>
 
-                    <Table.Body>
-                        {payments.map((payment, index) => (
-                            <Table.Row
-                                key={index}
-                                className="hover:bg-zinc-100 dark:hover:bg-zinc-800"
-                            >
-                                <Table.RowHeaderCell align="center">
-                                    {payment.id}
-                                </Table.RowHeaderCell>
-                                <Table.Cell align="center">
-                                    {new Date(payment.createdAt).toLocaleString(
-                                        'de-DE',
-                                        {
-                                            dateStyle: 'medium',
-                                            timeStyle: 'short',
-                                        }
+                <Table.Body>
+                    {payments.map((payment) => (
+                        <Table.Row
+                            key={payment.id}
+                            className="hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        >
+                            <Table.Cell>
+                                <Flex justify="center" align="center">
+                                    {payment.method && (
+                                        <PaymentLogo method={payment.method as string} />
                                     )}
-                                </Table.Cell>
-                                <Table.Cell align="center">
-                                    <StateBadge state={payment.status} />
-                                </Table.Cell>
-                                <Table.Cell align="center">
-                                    <IconButton
-                                        variant="outline"
-                                        aria-label="Details"
-                                        asChild
-                                    >
-                                        <Link href={'/payments/' + payment.id}>
-                                            <MagnifyingGlassIcon />
-                                        </Link>
-                                    </IconButton>
-                                </Table.Cell>
-                            </Table.Row>
-                        ))}
-                    </Table.Body>
-                </Table.Root>
-            </Flex>
+                                </Flex>
+                            </Table.Cell>
+                            <Table.Cell>
+                                {new Date(payment.createdAt).toLocaleString('de-DE', {
+                                    dateStyle: 'medium',
+                                    timeStyle: 'short',
+                                })}
+                            </Table.Cell>
+                            <Table.Cell>
+                                {payment.amount.currency} {payment.amount.value}
+                            </Table.Cell>
+                            <Table.Cell className="hidden sm:table-cell">
+                                <StateBadge state={payment.status} />
+                            </Table.Cell>
+                            <Table.Cell className="hidden md:table-cell">
+                                <div
+                                    style={{
+                                        maxWidth: '200px',
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis',
+                                        whiteSpace: 'nowrap',
+                                    }}
+                                    title={payment.description ?? undefined}
+                                >
+                                    {payment.description}
+                                </div>
+                            </Table.Cell>
+                            <Table.Cell className="hidden lg:table-cell">
+                                {payment.id}
+                            </Table.Cell>
+                            <Table.Cell align="center">
+                                <IconButton
+                                    variant="outline"
+                                    aria-label="Details"
+                                    asChild
+                                >
+                                    <Link href={'/payments/' + payment.id}>
+                                        <MagnifyingGlassIcon />
+                                    </Link>
+                                </IconButton>
+                            </Table.Cell>
+                        </Table.Row>
+                    ))}
+                </Table.Body>
+            </Table.Root>
         </Flex>
     );
 }

--- a/src/app/lib/mollie.ts
+++ b/src/app/lib/mollie.ts
@@ -34,6 +34,7 @@ if (!liveApiKey) {
 
 // Set up Mollie API client
 const mollieClient = createMollieClient({ apiKey: apiKey });
+const livePaymentsClient = createMollieClient({ apiKey: liveApiKey! });
 
 // translate countries to locales
 const countryToLocale: Record<string, Locale> = {
@@ -156,11 +157,22 @@ export async function mollieCreatePayment({
     return redirectUrl;
 }
 
-// Get the last 10 payments made
-
-export async function mollieGetPayments() {
-    const payments = await mollieClient.payments.page({ limit: 10 });
-    return payments;
+export async function mollieGetPayments(opts: {
+    mode?: 'test' | 'live';
+    from?: string;
+    limit?: number;
+} = {}) {
+    const { mode = 'test', from, limit = 20 } = opts;
+    const client = mode === 'live' ? livePaymentsClient : mollieClient;
+    const page = await client.payments.page({
+        limit,
+        ...(from ? { from } : {}),
+    });
+    return {
+        payments: Array.from(page),
+        nextPageCursor: page.nextPageCursor,
+        previousPageCursor: page.previousPageCursor,
+    };
 }
 
 // only get the latest payment

--- a/src/app/payments/page.tsx
+++ b/src/app/payments/page.tsx
@@ -1,15 +1,52 @@
 import { Flex, Heading } from '@radix-ui/themes';
+import { getSession } from '@/app/lib/auth';
+import { mollieGetPayments } from '@/app/lib/mollie';
+import { validateMolliePayment } from '@/app/lib/validation';
 import PaymentsTable from '../components/ui/paymentstable';
+import PaymentCards from '../components/ui/PaymentCards';
+import PaymentsControls from '../components/ui/PaymentsControls';
 
-export default function Page() {
+export default async function Page(props: {
+    searchParams?: Promise<{ mode?: string; from?: string }>;
+}) {
+    const searchParams = await props.searchParams;
+    const rawMode = searchParams?.mode;
+    const rawFrom = searchParams?.from;
+
+    const session = await getSession();
+    const isMollie = session?.isMollie === true;
+
+    const mode: 'test' | 'live' =
+        isMollie && rawMode === 'live' ? 'live' : 'test';
+
+    let from: string | undefined;
+    if (rawFrom) {
+        try {
+            from = await validateMolliePayment(rawFrom);
+        } catch {
+            from = undefined;
+        }
+    }
+
+    const { payments, nextPageCursor, previousPageCursor } =
+        await mollieGetPayments({ mode, from });
+
     return (
         <main>
-            <Flex
-                direction="column"
-                m="6"
-            >
+            <Flex direction="column" gap="4" m="6">
                 <Heading>Recent Payments</Heading>
-                <PaymentsTable />
+                <PaymentsControls
+                    isMollie={isMollie}
+                    mode={mode}
+                    nextCursor={nextPageCursor ?? null}
+                    prevCursor={previousPageCursor ?? null}
+                />
+                <div className="hidden md:block">
+                    <PaymentsTable payments={payments} />
+                </div>
+                <div className="block md:hidden">
+                    <PaymentCards payments={payments} />
+                </div>
             </Flex>
         </main>
     );


### PR DESCRIPTION
## Summary

- **Responsive table**: progressive column disclosure — method logo, timestamp, and amount always visible; status badge at `sm+`, description at `md+`, payment ID at `lg+`. Long descriptions are truncated with ellipsis (full text on hover).
- **Mobile card layout**: below the `md` breakpoint the table is replaced by a card-per-payment view showing logo, status, amount, timestamp, and payment ID.
- **Cursor-based pagination**: Previous/Next buttons update `?from=tr_xxx` in the URL; the page server component reads the cursor and passes it to the Mollie client's `.page()` call.
- **Live/test toggle**: a `<Switch>` gated to `@mollie.com` users (enforced both client- and server-side). Non-Mollie users see the switch disabled with a tooltip explaining why. Switching mode resets the pagination cursor.

## Test plan

- [x] Visit `/payments` on desktop — table renders with logo, timestamp, amount; resize to see more columns appear
- [x] Narrow browser below `md` — card layout appears instead of table
- [x] Click Next/Previous — URL updates with `?from=` cursor and correct page loads
- [x] Without sign-in: Switch is disabled; hovering shows tooltip
- [x] Sign in with `@mollie.com` Google account → Switch becomes enabled; toggling loads live payments and resets cursor

🤖 Generated with [Claude Code](https://claude.ai/claude-code)