### PR TITLE
Refactor payment details page with live mode, captures, and refunds

### DIFF
--- a/src/app/components/ui/PaymentCards.tsx
+++ b/src/app/components/ui/PaymentCards.tsx
@@ -4,12 +4,18 @@ import Link from 'next/link';
 import StateBadge from './orderstatebadge';
 import PaymentLogo from '../form/paymentlogo';
 
-export default function PaymentCards({ payments }: { payments: Payment[] }) {
+export default function PaymentCards({
+    payments,
+    mode = 'test',
+}: {
+    payments: Payment[];
+    mode?: 'test' | 'live';
+}) {
     return (
         <Flex direction="column" gap="3" pt="4">
             {payments.map((payment) => (
                 <Card key={payment.id} asChild>
-                    <Link href={`/payments/${payment.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+                    <Link href={`/payments/${payment.id}?mode=${mode}`} style={{ textDecoration: 'none', color: 'inherit' }}>
                         <Flex justify="between" align="center">
                             <Flex align="center" gap="2">
                                 {payment.method && (

--- a/src/app/components/ui/paymentoverview.tsx
+++ b/src/app/components/ui/paymentoverview.tsx
@@ -1,161 +1,671 @@
 'use server';
 
 // UI Components
-
 import {
     Flex,
+    Box,
     Code,
     Card,
     DataList,
-    Button,
     Separator,
-    Dialog,
     ScrollArea,
     Text,
+    Table,
+    Heading,
+    TextField,
 } from '@radix-ui/themes';
 import StateBadge from './orderstatebadge';
 
 // Routing
-import Link from 'next/link';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 // Mollie API
-import { mollieGetPayment, mollieCapturePayment } from '@/app/lib/mollie';
+import {
+    mollieGetPayment,
+    mollieCapturePayment,
+    mollieRefundPayment,
+    mollieReleaseAuthorization,
+} from '@/app/lib/mollie';
+import { validateCaptureAmount } from '@/app/lib/validation';
 import { Payment } from '@mollie/api-client';
+import PaymentLogo from '../form/paymentlogo';
+import SubmitButton from './submitbutton';
 
-export default async function PaymentOverview({ id }: { id: string }) {
-    // get details for this payment
-    const payment: Payment = await mollieGetPayment(id);
-    // server function for capturing this payment if authorized
-    async function capturePayment() {
+type CaptureRecord = {
+    id: string;
+    status: string;
+    amount: { value: string; currency: string };
+    createdAt: string;
+};
+
+type RefundRecord = {
+    id: string;
+    status: string;
+    amount: { value: string; currency: string };
+    createdAt: string;
+};
+
+type PaymentWithEmbedded = Payment & {
+    _embedded?: {
+        captures?: CaptureRecord[];
+        refunds?: RefundRecord[];
+    };
+};
+
+export default async function PaymentOverview({
+    id,
+    mode,
+}: {
+    id: string;
+    mode: 'test' | 'live';
+}) {
+    const payment = (await mollieGetPayment(id, mode)) as PaymentWithEmbedded;
+    const captures: CaptureRecord[] = payment._embedded?.captures ?? [];
+    const refunds: RefundRecord[] = payment._embedded?.refunds ?? [];
+
+    // amountRemaining is present once any capture/refund activity has occurred.
+    // For a fresh authorized payment it is absent, so fall back to amount − amountCaptured.
+    const remaining =
+        payment.amountRemaining?.value ??
+        Math.max(
+            0,
+            parseFloat(payment.amount.value) -
+                parseFloat(payment.amountCaptured?.value ?? '0'),
+        ).toFixed(2);
+    const remainingRefundable = payment.amountRemaining?.value ?? '0.00';
+
+    const canCapture =
+        payment.status === 'authorized' && parseFloat(remaining) > 0;
+    const showCapturesSection =
+        payment.status === 'authorized' || captures.length > 0;
+
+    const canRefund =
+        payment.status === 'paid' && parseFloat(remainingRefundable) > 0;
+    const showRefundsSection =
+        payment.status === 'paid' || refunds.length > 0;
+
+    const billingAddress = (payment as any).billingAddress as
+        | {
+              givenName?: string;
+              familyName?: string;
+              organizationName?: string;
+              streetAndNumber?: string;
+              postalCode?: string;
+              city?: string;
+              country?: string;
+              email?: string;
+          }
+        | undefined;
+
+    const lines = (payment as any).lines as
+        | Array<{
+              id?: string;
+              description: string;
+              quantity: number;
+              unitPrice: { value: string; currency: string };
+              totalAmount: { value: string; currency: string };
+          }>
+        | undefined;
+
+    const metadata = (payment as any).metadata as
+        | Record<string, unknown>
+        | undefined;
+
+    const hasOrderLines = !!(lines && lines.length > 0);
+
+    async function capturePayment(formData: FormData) {
         'use server';
-        await mollieCapturePayment(id);
+        const rawAmount = formData.get('amount') as string;
+        const validated = await validateCaptureAmount(
+            rawAmount,
+            remaining,
+        );
+        await mollieCapturePayment(id, mode, {
+            value: validated,
+            currency: payment.amount.currency,
+        });
         revalidatePath('/payments/' + id);
-        redirect('/payments/' + id);
+        redirect('/payments/' + id + '?mode=' + mode);
     }
+
+    async function releaseAuthorization() {
+        'use server';
+        await mollieReleaseAuthorization(id, mode);
+        revalidatePath('/payments/' + id);
+        redirect('/payments/' + id + '?mode=' + mode);
+    }
+
+    async function refundPayment(formData: FormData) {
+        'use server';
+        const rawAmount = formData.get('amount') as string;
+        const validated = await validateCaptureAmount(
+            rawAmount,
+            remainingRefundable,
+        );
+        await mollieRefundPayment(id, mode, {
+            value: validated,
+            currency: payment.amount.currency,
+        });
+        revalidatePath('/payments/' + id);
+        redirect('/payments/' + id + '?mode=' + mode);
+    }
+
     return (
-        <Flex
-            justify="center"
-            pt="4"
-        >
-            <Flex>
-                <Card>
-                    <DataList.Root>
-                        <DataList.Item align="center">
-                            <DataList.Label>ID</DataList.Label>
-                            <DataList.Value>
-                                <Code variant="ghost">{payment.id}</Code>
-                            </DataList.Value>
-                        </DataList.Item>
-                        <DataList.Item>
-                            <DataList.Label>Created At</DataList.Label>
-                            <DataList.Value>
-                                {new Date(payment.createdAt).toLocaleString(
-                                    'de-DE',
-                                    {
-                                        dateStyle: 'medium',
-                                        timeStyle: 'short',
-                                    }
-                                )}
-                            </DataList.Value>
-                        </DataList.Item>
-                        <DataList.Item>
-                            <DataList.Label>amount</DataList.Label>
-                            <DataList.Value>
-                                {payment.amount.value} {payment.amount.currency}
-                            </DataList.Value>
-                        </DataList.Item>
-                        <DataList.Item>
-                            <DataList.Label>Description</DataList.Label>
-                            <DataList.Value>
-                                {payment.description}
-                            </DataList.Value>
-                        </DataList.Item>
-                        <DataList.Item>
-                            <DataList.Label>Status</DataList.Label>
-                            <DataList.Value>
-                                <StateBadge state={payment.status} />
-                            </DataList.Value>
-                        </DataList.Item>
-                        <DataList.Item align="center">
-                            <DataList.Label>Payment Method</DataList.Label>
-                            <DataList.Value>
-                                <Code variant="ghost">{payment.method}</Code>
-                            </DataList.Value>
-                        </DataList.Item>
-                    </DataList.Root>
-                    <Separator
-                        my="3"
-                        size="4"
-                    />
-                    <Flex
-                        justify="center"
-                        align="center"
-                        gap="2"
-                    >
-                        <Link href={payment._links.dashboard.href}>
-                            <Button
-                                size="1"
-                                variant="soft"
-                                aria-label="Mollie Dashboard"
-                            >
-                                Mollie Dashboard
-                            </Button>
-                        </Link>
-                        <Dialog.Root>
-                            <Dialog.Trigger>
-                                <Button
-                                    size="1"
-                                    variant="soft"
-                                    aria-label="Raw Payment Data"
-                                >
-                                    Raw Payment Data
-                                </Button>
-                            </Dialog.Trigger>
-                            <Dialog.Content>
-                                <Dialog.Title>Raw Payment Data</Dialog.Title>
-                                <Separator
-                                    my="2"
-                                    size="4"
-                                />
-                                <ScrollArea style={{ height: 480 }}>
-                                    <Text size="1">
-                                        <pre>
-                                            {JSON.stringify(payment, null, 2)}
-                                        </pre>
-                                    </Text>
-                                </ScrollArea>
-                            </Dialog.Content>
-                        </Dialog.Root>
-                        {payment._links.changePaymentState && (
-                            <Link href={payment._links.changePaymentState.href}>
-                                <Button
-                                    size="1"
-                                    color="red"
-                                    variant="soft"
-                                    aria-label="Change State"
-                                >
-                                    Change State
-                                </Button>
-                            </Link>
+        <Flex direction="column" pt="4" gap="4">
+
+            {/* ── Row 1: Details card + Captures card side by side on desktop ── */}
+            <Flex
+                direction={{ initial: 'column', md: 'row' }}
+                gap="4"
+                align={{ initial: 'stretch', md: 'start' }}
+                justify="center"
+            >
+                {/* Details card */}
+                <Box style={{ flex: 1, minWidth: 0, maxWidth: 560 }}>
+                    <Card>
+                        <DataList.Root>
+                            <DataList.Item align="center">
+                                <DataList.Label>ID</DataList.Label>
+                                <DataList.Value>
+                                    <Code variant="ghost">{payment.id}</Code>
+                                </DataList.Value>
+                            </DataList.Item>
+                            <DataList.Item>
+                                <DataList.Label>Created At</DataList.Label>
+                                <DataList.Value>
+                                    {new Date(payment.createdAt).toLocaleString(
+                                        'de-DE',
+                                        {
+                                            dateStyle: 'medium',
+                                            timeStyle: 'short',
+                                        },
+                                    )}
+                                </DataList.Value>
+                            </DataList.Item>
+                            <DataList.Item>
+                                <DataList.Label>Amount</DataList.Label>
+                                <DataList.Value>
+                                    {payment.amount.value}{' '}
+                                    {payment.amount.currency}
+                                </DataList.Value>
+                            </DataList.Item>
+                            <DataList.Item>
+                                <DataList.Label>Description</DataList.Label>
+                                <DataList.Value>
+                                    {payment.description}
+                                </DataList.Value>
+                            </DataList.Item>
+                            <DataList.Item>
+                                <DataList.Label>Status</DataList.Label>
+                                <DataList.Value>
+                                    <StateBadge state={payment.status} />
+                                </DataList.Value>
+                            </DataList.Item>
+                            <DataList.Item align="center">
+                                <DataList.Label>Payment Method</DataList.Label>
+                                <DataList.Value>
+                                    <Flex align="center" gap="2">
+                                        {payment.method && (
+                                            <PaymentLogo
+                                                method={payment.method as string}
+                                            />
+                                        )}
+                                        <Code variant="ghost">
+                                            {payment.method}
+                                        </Code>
+                                    </Flex>
+                                </DataList.Value>
+                            </DataList.Item>
+                            {billingAddress && (
+                                <DataList.Item>
+                                    <DataList.Label>
+                                        Billing Address
+                                    </DataList.Label>
+                                    <DataList.Value>
+                                        <Flex direction="column" gap="1">
+                                            {(billingAddress.givenName ||
+                                                billingAddress.familyName) && (
+                                                <Text size="2">
+                                                    {[
+                                                        billingAddress.givenName,
+                                                        billingAddress.familyName,
+                                                    ]
+                                                        .filter(Boolean)
+                                                        .join(' ')}
+                                                </Text>
+                                            )}
+                                            {billingAddress.organizationName && (
+                                                <Text size="2" color="gray">
+                                                    {
+                                                        billingAddress.organizationName
+                                                    }
+                                                </Text>
+                                            )}
+                                            {billingAddress.streetAndNumber && (
+                                                <Text size="2">
+                                                    {
+                                                        billingAddress.streetAndNumber
+                                                    }
+                                                </Text>
+                                            )}
+                                            {(billingAddress.postalCode ||
+                                                billingAddress.city) && (
+                                                <Text size="2">
+                                                    {[
+                                                        billingAddress.postalCode,
+                                                        billingAddress.city,
+                                                    ]
+                                                        .filter(Boolean)
+                                                        .join(' ')}
+                                                </Text>
+                                            )}
+                                            {billingAddress.country && (
+                                                <Text size="2">
+                                                    {billingAddress.country}
+                                                </Text>
+                                            )}
+                                            {billingAddress.email && (
+                                                <Text size="2" color="gray">
+                                                    {billingAddress.email}
+                                                </Text>
+                                            )}
+                                        </Flex>
+                                    </DataList.Value>
+                                </DataList.Item>
+                            )}
+                            {metadata && Object.keys(metadata).length > 0 && (
+                                <DataList.Item>
+                                    <DataList.Label>Metadata</DataList.Label>
+                                    <DataList.Value>
+                                        <Text size="1">
+                                            <pre style={{ margin: 0 }}>
+                                                {JSON.stringify(
+                                                    metadata,
+                                                    null,
+                                                    2,
+                                                )}
+                                            </pre>
+                                        </Text>
+                                    </DataList.Value>
+                                </DataList.Item>
+                            )}
+                        </DataList.Root>
+
+                        {/* Order lines — heading gives visual break; no Separator before it
+                            to avoid doubling with the table's own bottom row border. */}
+                        {hasOrderLines && (
+                            <>
+                                <Heading size="2" mt="4" mb="2">
+                                    Order Lines
+                                </Heading>
+                                <Box style={{ overflowX: 'auto' }}>
+                                    <Table.Root
+                                        size="1"
+                                        variant="ghost"
+                                        style={{ minWidth: 360 }}
+                                    >
+                                        <Table.Header>
+                                            <Table.Row>
+                                                <Table.ColumnHeaderCell>
+                                                    Description
+                                                </Table.ColumnHeaderCell>
+                                                <Table.ColumnHeaderCell>
+                                                    Qty
+                                                </Table.ColumnHeaderCell>
+                                                <Table.ColumnHeaderCell>
+                                                    Unit Price
+                                                </Table.ColumnHeaderCell>
+                                                <Table.ColumnHeaderCell>
+                                                    Total
+                                                </Table.ColumnHeaderCell>
+                                            </Table.Row>
+                                        </Table.Header>
+                                        <Table.Body>
+                                            {lines!.map((line, i) => (
+                                                <Table.Row key={line.id ?? i}>
+                                                    <Table.Cell>
+                                                        {line.description}
+                                                    </Table.Cell>
+                                                    <Table.Cell>
+                                                        {line.quantity}
+                                                    </Table.Cell>
+                                                    <Table.Cell>
+                                                        {line.unitPrice.value}{' '}
+                                                        {line.unitPrice.currency}
+                                                    </Table.Cell>
+                                                    <Table.Cell>
+                                                        {line.totalAmount.value}{' '}
+                                                        {
+                                                            line.totalAmount
+                                                                .currency
+                                                        }
+                                                    </Table.Cell>
+                                                </Table.Row>
+                                            ))}
+                                        </Table.Body>
+                                    </Table.Root>
+                                </Box>
+                            </>
                         )}
-                        {payment.status == 'authorized' && (
-                            <form action={capturePayment}>
-                                <Button
-                                    size="1"
-                                    color="green"
-                                    variant="soft"
-                                    type="submit"
-                                    aria-label="Capture"
+
+                    </Card>
+                </Box>
+
+                {/* Right column: Captures + Refunds stacked */}
+                {(showCapturesSection || showRefundsSection) && (
+                    <Flex
+                        direction="column"
+                        gap="4"
+                        style={{ flex: 1, minWidth: 0, maxWidth: 560 }}
+                    >
+                        {/* Captures card */}
+                        {showCapturesSection && (
+                            <Card>
+                                <Heading size="3" mb="3">
+                                    Captures
+                                </Heading>
+
+                                {captures.length > 0 && (
+                                    <Box style={{ overflowX: 'auto' }}>
+                                        <Table.Root
+                                            size="1"
+                                            variant="ghost"
+                                            style={{ minWidth: 360 }}
+                                        >
+                                            <Table.Header>
+                                                <Table.Row>
+                                                    <Table.ColumnHeaderCell>
+                                                        ID
+                                                    </Table.ColumnHeaderCell>
+                                                    <Table.ColumnHeaderCell>
+                                                        Amount
+                                                    </Table.ColumnHeaderCell>
+                                                    <Table.ColumnHeaderCell>
+                                                        Status
+                                                    </Table.ColumnHeaderCell>
+                                                    <Table.ColumnHeaderCell>
+                                                        Created
+                                                    </Table.ColumnHeaderCell>
+                                                </Table.Row>
+                                            </Table.Header>
+                                            <Table.Body>
+                                                {captures.map((capture) => (
+                                                    <Table.Row key={capture.id}>
+                                                        <Table.Cell>
+                                                            <Code
+                                                                variant="ghost"
+                                                                size="1"
+                                                            >
+                                                                {capture.id}
+                                                            </Code>
+                                                        </Table.Cell>
+                                                        <Table.Cell>
+                                                            {
+                                                                capture.amount
+                                                                    .value
+                                                            }{' '}
+                                                            {
+                                                                capture.amount
+                                                                    .currency
+                                                            }
+                                                        </Table.Cell>
+                                                        <Table.Cell>
+                                                            <StateBadge
+                                                                state={
+                                                                    capture.status
+                                                                }
+                                                            />
+                                                        </Table.Cell>
+                                                        <Table.Cell>
+                                                            {new Date(
+                                                                capture.createdAt,
+                                                            ).toLocaleString(
+                                                                'de-DE',
+                                                                {
+                                                                    dateStyle:
+                                                                        'short',
+                                                                    timeStyle:
+                                                                        'short',
+                                                                },
+                                                            )}
+                                                        </Table.Cell>
+                                                    </Table.Row>
+                                                ))}
+                                            </Table.Body>
+                                        </Table.Root>
+                                    </Box>
+                                )}
+
+                                {captures.length === 0 && (
+                                    <Separator my="3" size="4" />
+                                )}
+
+                                {canCapture ? (
+                                    <Box mt={captures.length > 0 ? '3' : '0'}>
+                                        <Flex
+                                            align="center"
+                                            justify="between"
+                                            mb="3"
+                                        >
+                                            <Text size="2" color="gray">
+                                                Remaining capturable:
+                                            </Text>
+                                            <Text size="2" weight="bold">
+                                                {remaining}{' '}
+                                                {payment.amount.currency}
+                                            </Text>
+                                        </Flex>
+                                        <Flex direction="column" gap="2">
+                                            <form action={capturePayment} style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                                                <Flex align="center" justify="end" gap="2">
+                                                    <TextField.Root
+                                                        type="number"
+                                                        name="amount"
+                                                        defaultValue={remaining}
+                                                        min="0.01"
+                                                        max={remaining}
+                                                        step="0.01"
+                                                        style={{ width: 100 }}
+                                                    />
+                                                    <Text size="2">
+                                                        {
+                                                            payment.amount
+                                                                .currency
+                                                        }
+                                                    </Text>
+                                                    <SubmitButton
+                                                        label="Capture"
+                                                        color="green"
+                                                    />
+                                                </Flex>
+                                            </form>
+                                            <Separator size="4" />
+                                            <form action={releaseAuthorization}>
+                                                <Flex justify="end">
+                                                    <SubmitButton
+                                                        label="Release authorization"
+                                                        color="red"
+                                                    />
+                                                </Flex>
+                                            </form>
+                                        </Flex>
+                                    </Box>
+                                ) : (
+                                    <Box mt={captures.length > 0 ? '3' : '0'}>
+                                        <Text size="2" color="green">
+                                            Fully captured
+                                        </Text>
+                                    </Box>
+                                )}
+                            </Card>
+                        )}
+
+                        {/* Refunds card */}
+                        {showRefundsSection && (
+                            <Card>
+                                <Heading size="3" mb="3">
+                                    Refunds
+                                </Heading>
+
+                                {refunds.length > 0 && (
+                                    <Box style={{ overflowX: 'auto' }}>
+                                        <Table.Root
+                                            size="1"
+                                            variant="ghost"
+                                            style={{ minWidth: 360 }}
+                                        >
+                                            <Table.Header>
+                                                <Table.Row>
+                                                    <Table.ColumnHeaderCell>
+                                                        ID
+                                                    </Table.ColumnHeaderCell>
+                                                    <Table.ColumnHeaderCell>
+                                                        Amount
+                                                    </Table.ColumnHeaderCell>
+                                                    <Table.ColumnHeaderCell>
+                                                        Status
+                                                    </Table.ColumnHeaderCell>
+                                                    <Table.ColumnHeaderCell>
+                                                        Created
+                                                    </Table.ColumnHeaderCell>
+                                                </Table.Row>
+                                            </Table.Header>
+                                            <Table.Body>
+                                                {refunds.map((refund) => (
+                                                    <Table.Row key={refund.id}>
+                                                        <Table.Cell>
+                                                            <Code
+                                                                variant="ghost"
+                                                                size="1"
+                                                            >
+                                                                {refund.id}
+                                                            </Code>
+                                                        </Table.Cell>
+                                                        <Table.Cell>
+                                                            {
+                                                                refund.amount
+                                                                    .value
+                                                            }{' '}
+                                                            {
+                                                                refund.amount
+                                                                    .currency
+                                                            }
+                                                        </Table.Cell>
+                                                        <Table.Cell>
+                                                            <StateBadge
+                                                                state={
+                                                                    refund.status
+                                                                }
+                                                            />
+                                                        </Table.Cell>
+                                                        <Table.Cell>
+                                                            {new Date(
+                                                                refund.createdAt,
+                                                            ).toLocaleString(
+                                                                'de-DE',
+                                                                {
+                                                                    dateStyle:
+                                                                        'short',
+                                                                    timeStyle:
+                                                                        'short',
+                                                                },
+                                                            )}
+                                                        </Table.Cell>
+                                                    </Table.Row>
+                                                ))}
+                                            </Table.Body>
+                                        </Table.Root>
+                                    </Box>
+                                )}
+
+                                {refunds.length === 0 && (
+                                    <Separator my="3" size="4" />
+                                )}
+
+                                <Flex
+                                    align="center"
+                                    justify="between"
+                                    mb="3"
+                                    mt={refunds.length > 0 ? '3' : '0'}
                                 >
-                                    Capture
-                                </Button>
-                            </form>
+                                    <Text size="2" color="gray">
+                                        Remaining refundable:
+                                    </Text>
+                                    <Text size="2" weight="bold">
+                                        {remainingRefundable}{' '}
+                                        {payment.amount.currency}
+                                    </Text>
+                                </Flex>
+
+                                {canRefund && (
+                                    <form action={refundPayment} style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                                        <Flex align="center" justify="end" gap="2">
+                                            <TextField.Root
+                                                type="number"
+                                                name="amount"
+                                                defaultValue={remainingRefundable}
+                                                min="0.01"
+                                                max={remainingRefundable}
+                                                step="0.01"
+                                                style={{ width: 100 }}
+                                            />
+                                            <Text size="2">
+                                                {payment.amount.currency}
+                                            </Text>
+                                            <SubmitButton
+                                                label="Refund"
+                                                color="orange"
+                                            />
+                                        </Flex>
+                                    </form>
+                                )}
+
+                                {!canRefund &&
+                                    parseFloat(remainingRefundable) === 0 && (
+                                        <Text size="2" color="orange">
+                                            Fully refunded
+                                        </Text>
+                                    )}
+                            </Card>
                         )}
                     </Flex>
-                </Card>
+                )}
             </Flex>
+
+            {/* ── Row 2: Raw payment data — own card at the bottom ── */}
+            <Card>
+                <details>
+                    <summary style={{ cursor: 'pointer', userSelect: 'none' }}>
+                        <Text size="3" weight="bold">
+                            Raw Payment Data
+                        </Text>
+                    </summary>
+                    <Box
+                        mt="3"
+                        p="3"
+                        style={{
+                            background: 'var(--gray-a2)',
+                            borderRadius: 'var(--radius-2)',
+                        }}
+                    >
+                        <ScrollArea style={{ maxHeight: 600 }}>
+                            <Text size="1">
+                                <pre
+                                    style={{
+                                        margin: 0,
+                                        whiteSpace: 'pre-wrap',
+                                        wordBreak: 'break-word',
+                                    }}
+                                >
+                                    {JSON.stringify(payment, null, 2)}
+                                </pre>
+                            </Text>
+                        </ScrollArea>
+                    </Box>
+                </details>
+            </Card>
+
         </Flex>
     );
 }

--- a/src/app/components/ui/paymentstable.tsx
+++ b/src/app/components/ui/paymentstable.tsx
@@ -5,7 +5,13 @@ import Link from 'next/link';
 import StateBadge from './orderstatebadge';
 import PaymentLogo from '../form/paymentlogo';
 
-export default function PaymentsTable({ payments }: { payments: Payment[] }) {
+export default function PaymentsTable({
+    payments,
+    mode = 'test',
+}: {
+    payments: Payment[];
+    mode?: 'test' | 'live';
+}) {
     return (
         <Flex justify="center" pt="4">
             <Table.Root
@@ -78,7 +84,7 @@ export default function PaymentsTable({ payments }: { payments: Payment[] }) {
                                     aria-label="Details"
                                     asChild
                                 >
-                                    <Link href={'/payments/' + payment.id}>
+                                    <Link href={`/payments/${payment.id}?mode=${mode}`}>
                                         <MagnifyingGlassIcon />
                                     </Link>
                                 </IconButton>

--- a/src/app/components/ui/submitbutton.tsx
+++ b/src/app/components/ui/submitbutton.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+import { Button } from '@radix-ui/themes';
+
+export default function SubmitButton({
+    label,
+    color,
+}: {
+    label: string;
+    color: 'green' | 'orange' | 'red';
+}) {
+    const { pending } = useFormStatus();
+    return (
+        <Button
+            size="2"
+            variant="soft"
+            color={color}
+            type="submit"
+            loading={pending}
+            aria-label={label}
+        >
+            {label}
+        </Button>
+    );
+}

--- a/src/app/lib/mollie.ts
+++ b/src/app/lib/mollie.ts
@@ -182,10 +182,10 @@ export async function mollieGetLatestPaymentStatus() {
     return payment[0].status;
 }
 
-// Get a specific payment by its ID
-
-export async function mollieGetPayment(id: string) {
-    const payment = await mollieClient.payments.get(id);
+// Get a specific payment by its ID, with captures embedded
+export async function mollieGetPayment(id: string, mode: 'test' | 'live' = 'test') {
+    const client = mode === 'live' ? livePaymentsClient : mollieClient;
+    const payment = await client.payments.get(id, { embed: ['captures', 'refunds'] } as any);
     return payment;
 }
 
@@ -216,14 +216,35 @@ export async function mollieGetMethods(
     });
     return methods;
 }
-// Capture a payment in full
-
-export async function mollieCapturePayment(id: string) {
+export async function mollieCapturePayment(
+    id: string,
+    mode: 'test' | 'live' = 'test',
+    amount?: { value: string; currency: string },
+) {
+    const client = mode === 'live' ? livePaymentsClient : mollieClient;
     console.debug('Capturing payment with id: ' + id);
-    const capture = await mollieClient.paymentCaptures.create({
+    const capture = await client.paymentCaptures.create({
         paymentId: id,
+        ...(amount ? { amount } : {}),
     });
     return capture;
+}
+
+export async function mollieReleaseAuthorization(
+    id: string,
+    mode: 'test' | 'live' = 'test',
+) {
+    const client = mode === 'live' ? livePaymentsClient : mollieClient;
+    return client.payments.releaseAuthorization(id);
+}
+
+export async function mollieRefundPayment(
+    id: string,
+    mode: 'test' | 'live' = 'test',
+    amount: { value: string; currency: string },
+) {
+    const client = mode === 'live' ? livePaymentsClient : mollieClient;
+    return client.paymentRefunds.create({ paymentId: id, amount });
 }
 
 // mollieCreateSession creates a Mollie Session, which is the starting point for

--- a/src/app/lib/validation.ts
+++ b/src/app/lib/validation.ts
@@ -70,6 +70,26 @@ export async function validateCurrency(currency: string) {
     }
 }
 
+export async function validateCaptureAmount(amount: string, max: string): Promise<string> {
+    const maxNum = parseFloat(max);
+    const schema = z
+        .string()
+        .regex(/^\d+(\.\d{1,2})?$/, { message: 'Must be a valid amount (e.g. 10.00)' })
+        .refine(
+            (s) => {
+                const n = parseFloat(s);
+                return n > 0 && n <= maxNum;
+            },
+            { message: `Amount must be between 0.01 and ${max}` },
+        )
+        .transform((s) => parseFloat(s).toFixed(2));
+    try {
+        return schema.parse(amount);
+    } catch (error) {
+        throw new Error(`Invalid capture amount: ${error}`);
+    }
+}
+
 export async function validateCountry(country: string) {
     const currencySchema = z.string().toUpperCase().length(2);
     try {

--- a/src/app/payments/[id]/page.tsx
+++ b/src/app/payments/[id]/page.tsx
@@ -1,26 +1,39 @@
-import { Flex, Heading, Code } from '@radix-ui/themes';
+import { Flex, Heading } from '@radix-ui/themes';
+import { redirect } from 'next/navigation';
 
 import { validateMolliePayment } from '@/app/lib/validation';
+import { getSession } from '@/app/lib/auth';
 import PaymentOverview from '@/app/components/ui/paymentoverview';
 
 export default async function Page({
     params,
+    searchParams,
 }: {
     params: Promise<{ id: string }>;
+    searchParams?: Promise<{ mode?: string }>;
 }) {
     const input = (await params).id;
     const id = await validateMolliePayment(input);
+
+    const rawMode = (await searchParams)?.mode;
+    const session = await getSession();
+    const isMollie = session?.isMollie === true;
+
+    const mode: 'test' | 'live' =
+        isMollie && rawMode === 'live' ? 'live' : 'test';
+
+    if (rawMode === 'live' && !isMollie) {
+        redirect('/api/auth/login');
+    }
+
     return (
         <main>
             <Flex
                 direction="column"
                 m="6"
             >
-                <Heading>
-                    Payment: &nbsp;
-                    <Code variant="ghost">{id}</Code>
-                </Heading>
-                <PaymentOverview id={id} />
+                <Heading>Payment Details</Heading>
+                <PaymentOverview id={id} mode={mode} />
             </Flex>
         </main>
     );

--- a/src/app/payments/page.tsx
+++ b/src/app/payments/page.tsx
@@ -42,10 +42,10 @@ export default async function Page(props: {
                     prevCursor={previousPageCursor ?? null}
                 />
                 <div className="hidden md:block">
-                    <PaymentsTable payments={payments} />
+                    <PaymentsTable payments={payments} mode={mode} />
                 </div>
                 <div className="block md:hidden">
-                    <PaymentCards payments={payments} />
+                    <PaymentCards payments={payments} mode={mode} />
                 </div>
             </Flex>
         </main>


### PR DESCRIPTION
## Summary

- **Live payment support** — detail page accepts `?mode=live`, gated behind Mollie-email session auth; payments list links carry the mode through
- **Captures section** — partial capture with amount input, existing captures table, release authorization button; remaining capturable uses `amountRemaining` from the API (falls back to `amount - amountCaptured` for fresh authorized payments)
- **Refunds section** — partial refund with amount input, existing refunds table; remaining refundable uses `amountRemaining` from the API
- **Richer payment details** — payment method logo, billing address, metadata, and order lines in the details card
- **Responsive layout** — details card + right column (captures + refunds stacked) side by side on desktop, stacked on mobile
- **Raw payment data** — collapsible card at the bottom with a 600 px scroll area
- **Loading states** — new `SubmitButton` client component with `useFormStatus` + Radix `Button loading` prop
- **Cleanup** — removed Mollie dashboard link and Change State button

## Test plan

- [x] Test payment detail page loads for a test payment
- [x] Live payment requires Mollie login; redirects unsigned-in users
- [x] Captures section shows for `authorized` payments with correct remaining amount
- [x] Partial capture submits and updates the page
- [x] Release authorization button dismisses capture form and shows Fully captured
- [x] Refunds section shows for `paid` payments with correct remaining refundable amount
- [x] Partial refund submits and updates the page
- [x] Loading spinner appears on Capture / Refund / Release buttons during submission
- [x] Responsive layout on mobile — all cards stack full width

Generated with [Claude Code](https://claude.com/claude-code)