### PR TITLE
Refactor payment method authorization with dynamic capture mode UI

### DIFF
--- a/src/app/components/form/methods/hostedpaymentmethods-interactive.tsx
+++ b/src/app/components/form/methods/hostedpaymentmethods-interactive.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import {
+    Card,
+    Flex,
+    Separator,
+    Text,
+    Switch,
+    RadioCards,
+} from '@radix-ui/themes';
+import React, { useState } from 'react';
+import PaymentLogo from '@/app/components/form/paymentlogo';
+import {
+    ALWAYS_AUTHORIZE_METHODS,
+    OPTIONALLY_AUTHORIZE_METHODS,
+} from '@/app/lib/types';
+
+type MethodShape = { id: string; description: string };
+
+export default function HostedPaymentMethodsInteractive({
+    methods,
+}: {
+    methods: MethodShape[];
+}) {
+    const [selectedMethod, setSelectedMethod] = useState<string>(
+        methods[0]?.id ?? ''
+    );
+
+    const isAlwaysAuthorize = ALWAYS_AUTHORIZE_METHODS.includes(
+        selectedMethod as any
+    );
+    const isOptionalAuthorize = OPTIONALLY_AUTHORIZE_METHODS.includes(
+        selectedMethod as any
+    );
+
+    return (
+        <Card m="1">
+            <RadioCards.Root
+                value={selectedMethod}
+                onValueChange={setSelectedMethod}
+                name="payment_method"
+                columns={{ initial: '1', sm: '2' }}
+                size={{ initial: '1', sm: '2' }}
+                mb="3"
+            >
+                {methods.map((method) => (
+                    <React.Fragment key={method.id}>
+                        <RadioCards.Item
+                            value={method.id}
+                            aria-label={method.description}
+                        >
+                            <PaymentLogo method={method.id} />
+                            <Text>{method.description}</Text>
+                        </RadioCards.Item>
+                    </React.Fragment>
+                ))}
+            </RadioCards.Root>
+
+            {isAlwaysAuthorize && (
+                <input
+                    type="hidden"
+                    name="captureMode"
+                    value="manual"
+                />
+            )}
+
+            {isOptionalAuthorize && (
+                <>
+                    <Separator
+                        my="3"
+                        size="4"
+                    />
+                    <Flex>
+                        <Text
+                            as="label"
+                            size="2"
+                        >
+                            <Flex
+                                gap="2"
+                                direction="column"
+                            >
+                                <Flex gap="2">
+                                    <Switch
+                                        radius="full"
+                                        name="captureMode"
+                                        value="manual"
+                                        aria-label="Capture mode"
+                                    />
+                                    Authorize payment
+                                </Flex>
+                                <Text
+                                    size="1"
+                                    color="gray"
+                                >
+                                    Authorized payments need to be captured
+                                    later
+                                </Text>
+                            </Flex>
+                        </Text>
+                    </Flex>
+                </>
+            )}
+        </Card>
+    );
+}

--- a/src/app/components/form/methods/hostedpaymentmethods.tsx
+++ b/src/app/components/form/methods/hostedpaymentmethods.tsx
@@ -1,17 +1,5 @@
-import {
-    Card,
-    Flex,
-    Separator,
-    Text,
-    Switch,
-    RadioCards,
-} from '@radix-ui/themes';
-
-import React from 'react';
-
-import PaymentLogo from '@/app/components/form/paymentlogo';
-
 import { mollieGetMethods } from '@/app/lib/mollie';
+import HostedPaymentMethodsInteractive from './hostedpaymentmethods-interactive';
 
 export default async function HostedPaymentMethodCards({
     currency,
@@ -22,60 +10,12 @@ export default async function HostedPaymentMethodCards({
 }) {
     const methods = await mollieGetMethods(currency, country);
 
-    return (
-        <>
-            <Card m="1">
-                <RadioCards.Root
-                    defaultValue={methods[0]?.id}
-                    name="payment_method"
-                    columns={{ initial: '1', sm: '2' }}
-                    size={{ initial: '1', sm: '2' }}
-                    mb="3"
-                >
-                    {methods.map((method) => (
-                        <React.Fragment key={method.id}>
-                            <RadioCards.Item
-                                value={method.id}
-                                aria-label={method.description}
-                            >
-                                <PaymentLogo method={method.id} />
-                                <Text>{method.description}</Text>
-                            </RadioCards.Item>
-                        </React.Fragment>
-                    ))}
-                </RadioCards.Root>
-                <Separator
-                    my="3"
-                    size="4"
-                />
-                <Flex>
-                    <Text
-                        as="label"
-                        size="2"
-                    >
-                        <Flex
-                            gap="2"
-                            direction="column"
-                        >
-                            <Flex gap="2">
-                                <Switch
-                                    radius="full"
-                                    name="captureMode"
-                                    value={'manual'}
-                                    aria-label="Capture mode"
-                                />
-                                Authorize payment (Cards and Klarna only)
-                            </Flex>
-                            <Text
-                                size="1"
-                                color="gray"
-                            >
-                                Authorized payments need to be captured later
-                            </Text>
-                        </Flex>
-                    </Text>
-                </Flex>
-            </Card>
-        </>
-    );
+    // Serialize to plain objects before crossing the Server/Client boundary.
+    // Mollie SDK returns class instances; only primitive fields can be passed as props.
+    const serialized = methods.map((m) => ({
+        id: m.id,
+        description: m.description,
+    }));
+
+    return <HostedPaymentMethodsInteractive methods={serialized} />;
 }

--- a/src/app/components/form/methods/methodskeleton.tsx
+++ b/src/app/components/form/methods/methodskeleton.tsx
@@ -1,11 +1,8 @@
 import {
     Card,
-    Flex,
-    Separator,
     Text,
     RadioCards,
     Skeleton,
-    Switch,
 } from '@radix-ui/themes';
 import React from 'react';
 
@@ -73,44 +70,6 @@ export default async function MethodsSkeleton() {
                         </React.Fragment>
                     ))}
                 </RadioCards.Root>
-                <Separator
-                    my="3"
-                    size="4"
-                />
-                <Flex>
-                    <Text
-                        as="label"
-                        size="2"
-                    >
-                        <Flex
-                            gap="2"
-                            direction="column"
-                        >
-                            <Flex gap="2">
-                                <Skeleton>
-                                    <Switch
-                                        radius="full"
-                                        name="captureMode"
-                                        value={'manual'}
-                                        aria-label="Capture mode"
-                                    />
-                                </Skeleton>
-                                <Skeleton>
-                                    Authorize payment (Cards and Klarna only)
-                                </Skeleton>
-                            </Flex>
-                            <Skeleton>
-                                <Text
-                                    size="1"
-                                    color="gray"
-                                >
-                                    Authorized payments need to be captured
-                                    later
-                                </Text>
-                            </Skeleton>
-                        </Flex>
-                    </Text>
-                </Flex>
             </Card>
         </>
     );

--- a/src/app/lib/mollie.ts
+++ b/src/app/lib/mollie.ts
@@ -8,7 +8,7 @@ import createMollieClient, {
     PaymentLineCategory,
     PaymentMethod,
 } from '@mollie/api-client';
-import { CreatePaymentParams } from './types';
+import { CreatePaymentParams, ALWAYS_AUTHORIZE_METHODS } from './types';
 
 const apiKey = process.env.MOLLIE_API_KEY;
 const liveApiKey = process.env.MOLLIE_LIVE_API_KEY;
@@ -78,8 +78,8 @@ export async function mollieCreatePayment({
     // The Mollie API will handle validation and return appropriate errors if needed
     // This allows testing of beta payment methods that aren't in the TypeScript client yet
 
-    // Billink requires manual capture at all times
-    if (payment_method === 'billink') {
+    // These methods always require manual capture regardless of client input
+    if (ALWAYS_AUTHORIZE_METHODS.includes(payment_method as any)) {
         captureMode = CaptureMethod.manual;
     }
 

--- a/src/app/lib/types.ts
+++ b/src/app/lib/types.ts
@@ -14,6 +14,18 @@ export const ExtendedPaymentMethod = z.enum([
 // Export the type for use in other files
 export type ExtendedPaymentMethodType = z.infer<typeof ExtendedPaymentMethod>;
 
+export const ALWAYS_AUTHORIZE_METHODS = ['billink', 'riverty'] as const;
+
+export const OPTIONALLY_AUTHORIZE_METHODS = [
+    'creditcard',
+    'klarna',
+    'billie',
+    'vipps',
+    'vippsmobilepay',
+    'mobilepay',
+    'paypal',
+] as const;
+
 // Mollie Context types
 export type MollieInstance = {
     createComponent: (type: string) => {


### PR DESCRIPTION
## Summary

- Adds `ALWAYS_AUTHORIZE_METHODS` (billink, riverty) and `OPTIONALLY_AUTHORIZE_METHODS` (creditcard, klarna, billie, vipps, vippsmobilepay, mobilepay, paypal) constants as a single source of truth in `types.ts`
- Extends server-side `captureMode=manual` enforcement to riverty (previously only billink was covered)
- Splits `hostedpaymentmethods.tsx` into a thin Server Component (API fetch) and a new Client Component (`hostedpaymentmethods-interactive.tsx`) that tracks selected method in state
- Authorize switch is shown only for optional-authorize methods; must-authorize methods emit a hidden `captureMode=manual` input with no visible UI; all other methods show nothing
- Removes the skeleton switch section to avoid layout shift on hydration

## Test plan

- [x] Select iDEAL — authorize section should be hidden
- [x] Select Credit Card — authorize toggle should appear and be functional
- [x] Select Klarna — authorize toggle should appear and be functional
- [x] Select Billink — no authorize UI visible; payment should still be created with `captureMode=manual`
- [x] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)